### PR TITLE
Add observablehq.com to forbidden_hosts

### DIFF
--- a/main/extract_mastodon_ids.py
+++ b/main/extract_mastodon_ids.py
@@ -1,7 +1,7 @@
 import re
 import tweepy
 
-_forbidden_hosts = {'tiktok.com', 'youtube.com', 'medium.com', 'skeb.jp', 'pronouns.page', 'foundation.app', 'gamejolt.com', 'traewelling.de'}
+_forbidden_hosts = {'tiktok.com', 'youtube.com', 'medium.com', 'skeb.jp', 'pronouns.page', 'foundation.app', 'gamejolt.com', 'traewelling.de', 'observablehq.com'}
 
 # Matches anything of the form @foo@bar.bla or foo@bar.social or foo@social.bar or foo@barmastodonbla
 # We do not match everything of the form foo@bar or foo@bar.bla to avoid false positives like email addresses


### PR DESCRIPTION
example URL: https://observablehq.com/@j-f1. Observable does not provide fediverse functionality.